### PR TITLE
Fixing Educates repository links

### DIFF
--- a/docs/setup/educates.md
+++ b/docs/setup/educates.md
@@ -1,15 +1,15 @@
 # Installing the Educates CLI
 
 Next, we are going to install the Educates CLI from the available release binaries
-[on GitHub](https://github.com/vmware-tanzu-labs/educates-training-platform/releases).
+[on GitHub](https://github.com/educates/educates-training-platform/releases).
 
 === "Linux"
 
     ``` sh
     # For AMD64 / x86_64
-    [ $(uname -m) = x86_64 ] && curl -sSLo educates https://github.com/vmware-tanzu-labs/educates-training-platform/releases/latest/download/educates-linux-amd64
+    [ $(uname -m) = x86_64 ] && curl -sSLo educates https://github.com/educates/educates-training-platform/releases/latest/download/educates-linux-amd64
     # For ARM64
-    [ $(uname -m) = aarch64 ] && curl -sSLo educates https://github.com/vmware-tanzu-labs/educates-training-platform/releases/latest/download/educates-linux-arm64
+    [ $(uname -m) = aarch64 ] && curl -sSLo educates https://github.com/educates/educates-training-platform/releases/latest/download/educates-linux-arm64
     chmod +x educates
     sudo mv educates /usr/local/bin/educates
     ```
@@ -18,9 +18,9 @@ Next, we are going to install the Educates CLI from the available release binari
 
     ``` sh
     # For AMD64 / x86_64
-    [ $(uname -m) = x86_64 ] && curl -sSLo educates https://github.com/vmware-tanzu-labs/educates-training-platform/releases/latest/download/educates-darwin-amd64
+    [ $(uname -m) = x86_64 ] && curl -sSLo educates https://github.com/educates/educates-training-platform/releases/latest/download/educates-darwin-amd64
     # For ARM64
-    [ $(uname -m) = arm64 ] && curl -sSLo educates https://github.com/vmware-tanzu-labs/educates-training-platform/releases/latest/download/educates-darwin-arm64
+    [ $(uname -m) = arm64 ] && curl -sSLo educates https://github.com/educates/educates-training-platform/releases/latest/download/educates-darwin-arm64
     chmod +x educates
     sudo mv educates /usr/local/bin/educates
     ```


### PR DESCRIPTION
Updating the links to the Educates project to point to the Educates org, now that the project has moved.

Fixes #1 